### PR TITLE
Fix IOError when the logfile is shorter than config['LOG_PARSE']

### DIFF
--- a/client/gentwoo.py
+++ b/client/gentwoo.py
@@ -97,7 +97,10 @@ def searchLog(package, config):
     begTime = None
     endTime = None
     with open(config['PORTAGE_LOG']) as plf:
-        plf.seek(-config['LOG_PARSE'], os.SEEK_END)
+        try:
+            plf.seek(-config['LOG_PARSE'], os.SEEK_END)
+        except IOError:
+            plf.seek(0, os.SEEK_SET)
         lines = plf.readlines()
         for l in  reversed(lines[1:]):
             if not endTime:


### PR DESCRIPTION
ログファイルが config で指定された長さないときに、エラーになっていたのを対処しました。
Python は初心者なので正しい方法かわからないのですが…
