### PR TITLE
Gentoo-Prefixで使用すると EPREFIXの値が取得できずにconfigの値がとれない

### DIFF
--- a/client/gentwoo.py
+++ b/client/gentwoo.py
@@ -9,6 +9,7 @@ import re
 import datetime
 import time
 from portage.util import getconfig
+from portage.const import EPREFIX
 
 class Query:
     def __init__(self, config, package, begin, end, logfile):
@@ -129,8 +130,7 @@ def trySearchLog(package, config):
     return (None, None)
 
 if __name__ == "__main__":
-    eprefix = os.environ.get("EPREFIX", "/")
-    config = loadConfig(os.path.join(os.sep, eprefix.lstrip(os.sep),
+    config = loadConfig(os.path.join(os.sep, EPREFIX.lstrip(os.sep),
                                      'etc', 'gentwoo.conf'))
     if config is None:
       sys.exit(1)


### PR DESCRIPTION
`EPREFIX`の値がとれてずに、`/etc/gentwoo.conf` が読めていなかったので `portage.const.EPREFIX` の値を利用して参照するように変更してみました。

一応EPREFIXの設定されてない環境の動作も確認しました。
